### PR TITLE
Make script more robust if USE_UNISON_SYNC is not set

### DIFF
--- a/conf/entrypoint.sh
+++ b/conf/entrypoint.sh
@@ -60,7 +60,7 @@ then
     fi
 fi
 
-if [ $USE_UNISON_SYNC == "1" ]
+if [ "$USE_UNISON_SYNC" == "1" ]
 then
     sudo -u magento2 sh -c '/usr/local/bin/unison -socket 5000 2>&1 >/dev/null' &
 fi


### PR DESCRIPTION
If you forget to set this variable the script aborts with a syntax error. Nicer to just not enable syncing. Always safer to put variables in double quotes in shells scripts for this reason.