### PR TITLE
Setting magento2 user to NOPASSWD in /etc/sudoers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ RUN apt-get update && apt-get install -y \
     && a2enmod proxy_fcgi \
     && rm -f /etc/apache2/sites-enabled/000-default.conf \
     && useradd -m -d /home/magento2 -s /bin/bash magento2 && adduser magento2 sudo \
+    && echo "magento2 ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers \
     && touch /etc/sudoers.d/privacy \
     && echo "Defaults        lecture = never" >> /etc/sudoers.d/privacy \
     && mkdir /home/magento2/magento2 && mkdir /var/www/magento2 \


### PR DESCRIPTION
As noted in Issue #117 the Magento Devbox init script issues some sudo commands as user `magento2` which prompt for a password, which doesn't exist, so it fails. 

This attempts to solve this issue by making the "magento2" user not required to a password to `sudo`. This fixed the issue for me, and the init script completes now.

It's also nice if you `bash` into the `web` container to be able to issue `sudo` commands now.

Since this is a trusted local environment, I can't see any downsides to enabling password-less-sudo for the `magento2` user.